### PR TITLE
fix: /page fails to fetch username when accessing null page

### DIFF
--- a/src/commands/page.ts
+++ b/src/commands/page.ts
@@ -44,7 +44,7 @@ export class PageCommand {
 
 		if (chosenUser == null) {
 			await interaction.reply({
-				embeds: [embeds.notLinked(member)],
+				embeds: [embeds.notLinked(member.user)],
 				ephemeral: true
 			});
 			return;


### PR DESCRIPTION
Closes #1 